### PR TITLE
fix(handlers): use optional chaining to prevent crash

### DIFF
--- a/src/socketserver/state.js
+++ b/src/socketserver/state.js
@@ -154,7 +154,7 @@ export const makeUserHost = (socketId) => {
 
 export const isUserInRoom = ({ roomId, socketId }) => rooms.get(roomId).users.has(socketId);
 
-export const getSocketPingSecret = (socketId) => socketLatencyData.get(socketId).secret;
+export const getSocketPingSecret = (socketId) => socketLatencyData.get(socketId)?.secret;
 
 export const updateSocketLatency = (socketId) => {
   const latencyData = socketLatencyData.get(socketId);
@@ -178,7 +178,7 @@ export const setSocketLatencyIntervalId = ({ socketId, intervalId }) => {
   socketLatencyData.get(socketId).intervalId = intervalId;
 };
 
-export const doesSocketHaveRtt = (socketId) => socketLatencyData.get(socketId).rtt != null;
+export const doesSocketHaveRtt = (socketId) => socketLatencyData.get(socketId)?.rtt != null;
 
 export const initSocketLatencyData = (socketId) => {
   socketLatencyData.set(socketId, {});


### PR DESCRIPTION
Previously, I didn't expect any event handlers to be run after a socket disconnects, but it appears it's possible, so this adds safety in that case so it doesn't crash the entire server