### PR TITLE
ci(node): use node 16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: 15
+          node-version: 16
 
       - name: Cache Node.js modules
         id: cache
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: 15
+          node-version: 16
 
       - name: Turnstyle
         uses: softprops/turnstyle@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12, 14, 15]
+        node-version: [12, 14, 16]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Switch the use of node 15 in our actions to node 16 now that node
15 isn't supported anymore.
https://nodejs.org/en/about/releases/